### PR TITLE
Fix broken rss feed

### DIFF
--- a/rss.esh
+++ b/rss.esh
@@ -14,7 +14,7 @@
       <% for f in `ls -t ./posts`; do
           file="./posts/"$f
           post_date=$(date -u -r "$file" "+%a, %d %b %Y %H:%M:00 %z")
-          html=$(pandoc -t html "$file")
+          html=$(pandoc -t html "$file" | sed -e "s/&/\&amp;/g" -e "s/</\&lt;/g" -e "s/>/\&gt;/g")
           id="${file##*/}"
           id="${id%.*}"
           post_title=$(echo "$id" | sed -E -e "s/\..+$//g"  -e "s/_(.)/ \u\1/g" -e "s/^(.)/\u\1/g")


### PR DESCRIPTION
This PR fixes the RSS feed - it escapes the HTML post contents with `sed`. (You might actually prefer using [`recode`](https://github.com/pinard/Recode) for this purpose.)

(This PR doesn't update the files in the `docs` directory: I ran it on my Mac and it resulted in some big differences, which looks like the difference between `gsed` and `sed`.)